### PR TITLE
Added argument to set CLI locale

### DIFF
--- a/BackupUtil.Cli/Command/LoadJobsCommand.cs
+++ b/BackupUtil.Cli/Command/LoadJobsCommand.cs
@@ -11,7 +11,7 @@ public class LoadJobsCommand
 {
     public static System.CommandLine.Command Build()
     {
-        Argument<string> jobFilePath = new("job-file-path", "File path to load the jobs from");
+        Argument<FileSystemInfo> jobFilePath = new("job-file-path", "File path to load the jobs from");
 
         System.CommandLine.Command command = new("load", "Load jobs from a file and execute them");
 
@@ -24,11 +24,11 @@ public class LoadJobsCommand
         return command;
     }
 
-    private static void CommandHandler(string jobFilePath)
+    private static void CommandHandler(FileSystemInfo jobFilePath)
     {
         try
         {
-            JobManager jobManager = new JobManager().LoadJobsFromFile(jobFilePath);
+            JobManager jobManager = new JobManager().LoadJobsFromFile(jobFilePath.FullName);
 
             // Show loaded jobs
             Console.Write(DisplayJobs.Display(jobManager.Jobs));

--- a/BackupUtil.Cli/Command/SingleJobCommand.cs
+++ b/BackupUtil.Cli/Command/SingleJobCommand.cs
@@ -10,10 +10,10 @@ internal class SingleJobCommand
 {
     public static System.CommandLine.Command Build()
     {
-        Argument<string> sourcePath = new("source-path", "Source path of the backup");
-        Argument<string> targetPath = new("target-path", "Target path of the backup");
-        Option<bool> recursive = new("--recursive", "Make the backup recursive");
-        Option<bool> differential = new("--differential", "Make the backup differential");
+        Argument<FileSystemInfo> sourcePath = new("source-path", "Source path of the backup");
+        Argument<FileSystemInfo> targetPath = new("target-path", "Target path of the backup");
+        Option<bool> recursive = new(["--recursive", "-r"], "Make the backup recursive");
+        Option<bool> differential = new(["--differential", "-d"], "Make the backup differential");
 
         System.CommandLine.Command command = new("run", "Run a single backup job");
 
@@ -32,9 +32,9 @@ internal class SingleJobCommand
         return command;
     }
 
-    private static void CommandHandler(string sourcePath, string targetPath, bool recursive, bool differential)
+    private static void CommandHandler(FileSystemInfo sourcePath, FileSystemInfo targetPath, bool recursive, bool differential)
     {
-        Job job = new(sourcePath, targetPath, recursive, differential);
+        Job job = new(sourcePath.FullName, targetPath.FullName, recursive, differential);
 
         JobManager jobManager = new();
 

--- a/BackupUtil.Cli/Program.cs
+++ b/BackupUtil.Cli/Program.cs
@@ -1,5 +1,8 @@
 ﻿using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Globalization;
 using BackupUtil.Cli.Command;
+using BackupUtil.I18n;
 
 namespace BackupUtil.Cli;
 
@@ -7,12 +10,49 @@ internal class Program
 {
     private static int Main(string[] args)
     {
+        Option<string> localeOption = new(["--locale", "-l"],
+            "Locale of the application, example: 'fr-FR', 'en-GB', defaults to OS locale");
+
+        localeOption.AddValidator(result => SetLocale(result, localeOption));
+
         RootCommand rootCommand =
         [
             SingleJobCommand.Build(),
             LoadJobsCommand.Build()
         ];
 
+        rootCommand.AddGlobalOption(localeOption);
+
+
         return rootCommand.Invoke(args);
+    }
+
+
+    private static void SetLocale(OptionResult result, Option<string> localeOption)
+    {
+        if (result.GetValueForOption(localeOption) is not string locale)
+        {
+            return;
+        }
+
+        CultureInfo culture;
+
+        try
+        {
+            culture = CultureInfo.GetCultureInfo(locale);
+        }
+        catch
+        {
+            Console.WriteLine("Invalid locale");
+            return;
+        }
+
+        if (!I18N.GetSupportedCultures().Contains(culture))
+        {
+            Console.WriteLine("Unsupported locale");
+            return;
+        }
+
+        I18N.SetCulture(new CultureInfo(locale));
     }
 }


### PR DESCRIPTION
- The locale of the CLi can now be set with the "--locale" option
- Added short aliases to each CLI optional arg
- File path arguments now have the FileSystemInfo type instead of string