### PR TITLE
Simplified job handling

### DIFF
--- a/BackupUtil.Cli/Command/CreateJobCommand.cs
+++ b/BackupUtil.Cli/Command/CreateJobCommand.cs
@@ -13,7 +13,9 @@ internal static class CreateJobCommand
         Option<string> name = new(["--name", "-n"], "Name of the job");
         Option<bool> recursive = new(["--recursive", "-r"], "Make the backup recursive");
         Option<bool> differential = new(["--differential", "-d"], "Make the backup differential.");
-        Option<FileSystemInfo> jobFilePath = new(["--job-file-path", "-o"], "File path to save the job to");
+
+        // Path of the job file
+        Option<FileSystemInfo> jobFilePath = new(["--job-file-path", "-o"], "Job file path");
 
         System.CommandLine.Command command = new("create", "Create a backup job and write it to a file");
 

--- a/BackupUtil.Cli/Command/RemoveJobCommand.cs
+++ b/BackupUtil.Cli/Command/RemoveJobCommand.cs
@@ -10,7 +10,8 @@ public class RemoveJobCommand
 {
     public static System.CommandLine.Command Build()
     {
-        Option<FileSystemInfo> jobFilePath = new(["--job-file-path", "-o"], "File path to remove the job from");
+        // Path of the job file
+        Option<FileSystemInfo> jobFilePath = new(["--job-file-path", "-o"], "Job file path");
 
         System.CommandLine.Command command = new("remove", "Remove a backup job from a file");
 

--- a/BackupUtil.Core/Job/Exporter/JobFileExporter.cs
+++ b/BackupUtil.Core/Job/Exporter/JobFileExporter.cs
@@ -17,6 +17,14 @@ internal static class JobFileExporter
             _ => throw new ArgumentException("errorFileFormatNotSupported")
         };
 
+        string? directoryName = Path.GetDirectoryName(filePath);
+
+        // Create the directory if it doesn't exist
+        if (!string.IsNullOrEmpty(directoryName))
+        {
+            Directory.CreateDirectory(directoryName);
+        }
+
         File.WriteAllText(filePath, serializedJobs);
     }
 }

--- a/BackupUtil.Core/Util/Config.cs
+++ b/BackupUtil.Core/Util/Config.cs
@@ -3,7 +3,9 @@ namespace BackupUtil.Core.Util;
 internal static class Config
 {
     // Default file path to look for a job file
-    public static string DefaultJobFilePath { get; } = "BackupJobs.json";
+    public static readonly string DefaultJobFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "EasySave", "Jobs", "BackupJobs.json");
 
     // Default max job count for the job manager
     public static uint DefaultMaxJobCount { get; } = 5;

--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ or load a list of backup jobs from a json file (`BackupUtil.Cli load ...`) and p
 You need to create a backup job before being able to load and run it.
 Backup jobs can be created using `Backuputil.Cli create ...`.
 
-If no filepath is specified, backup jobs are saved to, removed and loaded from `BackupJobs.json` in the CWD by default.
+If no filepath is specified, backup jobs are saved to, removed and loaded from:
+
+- Linux: `~/.locale/share/EasySave/Jobs/BackupJobs.json`
+- Windows: `~\AppData\Local\EasySave\Jobs\BackupJobs.json`
 
 A daily log file containing details about all changes made by this utility can be found at:
 
-- Linux: ~/.locale/share/EasySave/logs
-- Windows: ~\AppData\Local\EasySave\Logs
+- Linux: `~/.locale/share/EasySave/Logs`
+- Windows: `~\AppData\Local\EasySave\Logs`
 
 Currently, two languages are supported: French and English.
 If your OS language is among them, the CLI will default to it.
@@ -47,7 +50,7 @@ Options:
 
 Commands:
   create <source-path> <target-path>  Create a backup job and write it to a file
-  load <job-file-path>                Load backup jobs from a file and execute them
+  load                                Load backup jobs from a file and execute them
   remove                              Remove a backup job from a file
   run <source-path> <target-path>     Run a backup job
 ```


### PR DESCRIPTION
- Jobs are now saved to a standard directory instead of the CWD
- When creating a job file, containing dirs are also automatically created
- Job file path is now an optional argument for all subcommands that require it
- Updated README.md