### PR TITLE
Fixed job deletions

### DIFF
--- a/BackupUtil.Core/Job/JobManager.cs
+++ b/BackupUtil.Core/Job/JobManager.cs
@@ -92,7 +92,7 @@ public class JobManager
 
     public JobManager RemoveByIndices(HashSet<int> jobIndices)
     {
-        foreach (int jobIndex in jobIndices)
+        foreach (int jobIndex in jobIndices.OrderDescending())
         {
             Jobs.RemoveAt(jobIndex);
         }


### PR DESCRIPTION
- Removing a job would shift all elements after it in the list down by one.
- If a deletion is then attempted at a higher index, the wrong element may be deleted.
- Jobs are now deleted in descending order of their indices to prevent such incorrect deletions