### PR TITLE
File path validation fixes

### DIFF
--- a/BackupUtil.Core/Transaction/BackupTransactionBuilder.cs
+++ b/BackupUtil.Core/Transaction/BackupTransactionBuilder.cs
@@ -67,19 +67,19 @@ internal class BackupTransactionBuilder : IBackupTransactionBuilder
             throw new ArgumentException("errorSameSourceTarget");
         }
 
-        if (job.TargetPath.StartsWith(job.SourcePath))
+        if (job.TargetPath.StartsWith(job.SourcePath + Path.DirectorySeparatorChar))
         {
             throw new ArgumentException("errorTargetInSource");
         }
 
-        if (job.SourcePath.StartsWith(job.TargetPath))
+        if (job.SourcePath.StartsWith(job.TargetPath + Path.DirectorySeparatorChar))
         {
             throw new ArgumentException("errorSourceInTarget");
         }
 
         if (File.Exists(job.SourcePath))
         {
-            if (job.TargetPath.EndsWith('\\'))
+            if (job.TargetPath.EndsWith(Path.DirectorySeparatorChar))
             {
                 throw new ArgumentException("errorTargetPathEnd");
             }

--- a/BackupUtil.ViewModel/ViewModel/JobCreationViewModel.cs
+++ b/BackupUtil.ViewModel/ViewModel/JobCreationViewModel.cs
@@ -77,7 +77,7 @@ public class JobCreationViewModel : ViewModelBase, INotifyDataErrorInfo
     private bool SourcePathExists => Directory.Exists(SourcePath) || File.Exists(SourcePath);
 
     private bool SourcePathOutsideOfTargetPath =>
-        !SourcePath.StartsWith(TargetPath, StringComparison.OrdinalIgnoreCase);
+        !SourcePath.StartsWith(TargetPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
 
     public string SourcePath
     {
@@ -114,7 +114,7 @@ public class JobCreationViewModel : ViewModelBase, INotifyDataErrorInfo
         !string.Equals(SourcePath, TargetPath, StringComparison.OrdinalIgnoreCase);
 
     private bool TargetPathOutsideOfSourcePath =>
-        !TargetPath.StartsWith(SourcePath, StringComparison.OrdinalIgnoreCase);
+        !TargetPath.StartsWith(SourcePath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
 
     // Source and target both have to be either files or directories
     private bool TargetPathSameTypeAsSourcePath => File.Exists(SourcePath)


### PR DESCRIPTION
- Fixed checking if the source directory was inside the target, or the other way around
- The platform-specific path separator is now always used